### PR TITLE
Updated getShipMaxWeight to not apply to custom ships

### DIFF
--- a/SaneInventory/SaneInventory.cs
+++ b/SaneInventory/SaneInventory.cs
@@ -191,8 +191,9 @@ namespace SaneInventory
                 return shipKarveCargoWeightLimitConfig.Value;
             if (name.ToLower().Contains("vikingship"))
                 return shipLongboatCargoWeightLimitConfig.Value;
-
-            return 0;
+                
+            // unlimited weight for custom ship mods
+            return Int64.MaxValue;
         }
 
         private void bindConfig()


### PR DESCRIPTION
When using [OdinShip ](https://www.nexusmods.com/valheim/mods/1741?tab=description) mod, we're experiencing a game crash for the non-default ships. This is related to a divide by zero error found in the [ship sink gravity calculation](https://github.com/remmizekim/ValheimMods/blob/main/SaneInventory/SaneInventory.cs#L164).